### PR TITLE
Readme: Connection information

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,57 @@ Install bluetooth and bring up local device:
         
 And you're ready to rock. You'll find the usual block documentation below.
 
+## Method to connect to SensorTag and configure the Sensor Tag block in the Service Builder
+
+Steps **A** and **B** must be done during a reboot/power cycle of the Raspberry Pi. Step **C** is neccesary every time you start a service using a SensorTag.
+
+### A) Configuring Bluetooth Adapter
+
+By default, the Raspberry Pi will not have it's Blue Tooth adapter on. To enable it, you must cycle the Blue Tooth adapter using the following commands in the command line:
+
+        $ sudo hciconfig hci0 down
+        $ sudo hciconfig hci0 up
+        $ sudo hciconfig hci0 leadv 3
+        $ sudo hciconfig hci0 piscan
+
+### B) Finding SensorTag using Bluetooth advertise and discovery
+
+The next step will help with obtaining the MAC address of the Sensor Tag. It is neccesary to verify that the Raspberry Pi can find the Sensor Tag first. Steps 1 and 2 will accomplish this:
+
+1. Press the side button to enter into 'advertising' mode, it will stay in this mode for 30 seconds after being pressed.
+2. In the command line, enter the following:
+        
+        $ sudo hcitool lescan
+
+In the command line, you should now see a list of MAC addresses, one of which will be followed by 'sensortag' - **_this is the MAC address you will need for configuring the Sensor Tag block in the Address field_**.
+
+**_Note:_** If you fail to see a MAC address show up with 'sensortag' following it
+
+1. It is possible that the 30 second window has elapsed from pressing the button, to performing the 'lescan'
+  1. Repeat steps 1 and 2 above, making sure to perform both within a 30 second window or less.
+2. It is possible that the battery in the Sensor Tag is dead
+  1. Replace the CR2032 battery in the SensorTag with a new one.
+3. Beyond this - [resort to the manual from Texas Instruments](http://www.ti.com/lit/ml/swru324b/swru324b.pdf)
+
+### C) Configuring Service builder, and performing HTTP connect command
+
+In the service builder, drag a **SensorTagRead** block onto the workspace. The **Address** field will be filled in with the MAC address you recorded in step **B**. Configure the block to record any data parameter you want by selecting them. After saving the block and service proceed to the following steps.
+
+1. Start service
+2. After succesful start (and within 3 seconds of eachother)
+  1. press *Advertise* button on the side of the SensorTag
+  2. visit the following URL in browser: http://[[NIOHOST]]:[[NIOPORT]]/services/{{service_name}}/{{block_name}}/connect
+    * [[NIOHOST]] - the Rasperry Pi's service builder IPv4 Address
+    * [[NIOPORT]] - the port the service builder is open to - *usually 8181 by default*.
+    * {{service_name}} - the service name in which the **SensorTagRead** block is in.
+    * {{block_name}} - the name given to the **SensorTagRead** block being configuring right now.
+    * An example is as follows: http://192.168.100.72:8181/services/BlueTooth_SensorTag/Test1/connect 
+
+If succesful, you should see the output of the sensor tag show up in a log (assuming you are running the output of the **SensorTagRead** block into a logger). If you do not see anything showing up in the log, repeat steps 2-1 and 2-2 again. If you do not see anything showing up in the logger block try the following steps:
+
+1. Make sure the MAC address entered in the **SensorTagRead** block matches the MAC address of the SensorTag itself. 
+2. Press the *Advertise* a few more times.
+3. Restart service, and proceed to steps 2-1 and 2-2 again.
 
 Properties
 --------------

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Install bluetooth and bring up local device:
         
 And you're ready to rock. You'll find the usual block documentation below.
 
-## Method to connect to SensorTag and configure the Sensor Tag block in the Service Builder
+## Method to connect to SensorTag and configure the SensorTagRead block in the Service Builder
 
 Steps **A** and **B** must be done during a reboot/power cycle of the Raspberry Pi. Step **C** is neccesary every time you start a service using a SensorTag.
 


### PR DESCRIPTION
Updated the readme file to reflect the complicated methodology for connecting the sensortag when running the block. 

This is only an as-is update and the block needs to be reviewed to fully automate the connection sequence if we are to use this block reliably in a demo. Right now there is far too much work involved on the user end to connect a sensor tag when using this block. 