### PR TITLE
Lock keypress and sensor reads

### DIFF
--- a/sensor_tag_read_block.py
+++ b/sensor_tag_read_block.py
@@ -165,7 +165,7 @@ class SensorTagRead(Block):
         for s in sensors:
             s.enable()
             if s.__class__.__name__ == 'KeypressSensor':
-                self._tags[addy].setDelegate(
+                tag.setDelegate(
                     KeypressDelegate(self._logger, self.notify_signals))
         self._logger.debug("Sensors enabled: {}".format(addy))
 

--- a/tests/test_sensor_tag_read_block.py
+++ b/tests/test_sensor_tag_read_block.py
@@ -66,21 +66,25 @@ class TestSensorTagRead(NIOBlockTestCase):
         # wait for tag to connect and sensors to enable
         sleep(0.1)
         # Connected status is emitted on successful start.
-        self.assertEqual(1, len(self.signals['status']))
-        self.assertEqual('Connected', self.signals['status'][0].status)
+        self.assertEqual(3, len(self.signals['status']))
         self.assertEqual('SensorTag', self.signals['status'][0].name)
+        self.assertEqual('Connecting', self.signals['status'][0].status)
+        self.assertEqual('Enabling', self.signals['status'][1].status)
+        self.assertEqual('Connected', self.signals['status'][2].status)
         self.assertEqual('12:34:56:78:12:34',
                          self.signals['status'][0].address)
         # Connected status is emitted on successful start.
         blk._reconnect_thread(addy, read_on_connect=False)
         sleep(0.1)
-        self.assertEqual(3, len(self.signals['status']))
-        self.assertEqual('Disconnected', self.signals['status'][1].status)
-        self.assertEqual('Connected', self.signals['status'][2].status)
+        self.assertEqual(7, len(self.signals['status']))
+        self.assertEqual('Disconnected', self.signals['status'][3].status)
+        self.assertEqual('Connecting', self.signals['status'][4].status)
+        self.assertEqual('Enabling', self.signals['status'][5].status)
+        self.assertEqual('Connected', self.signals['status'][6].status)
         blk.stop()
         # Should stop emit a disconnect signal? What if we aad a feature in
         # the future where block can stop without stopping the service?
-        self.assertEqual(3, len(self.signals['status']))
+        self.assertEqual(7, len(self.signals['status']))
         self.assertEqual(0, len(self.signals['default']))
 
     def test_keypress_delegate(self, mock_tag):


### PR DESCRIPTION
This makes it so that you can have one SensorTag that both reads from sensors and keypress.