### PR TITLE
Fix infinitely-recurrent exceptions

### DIFF
--- a/sensor_tag_read_block.py
+++ b/sensor_tag_read_block.py
@@ -149,14 +149,12 @@ class SensorTagRead(Block):
             self._enable_sensors(addy, tag)
             # Save the tag to the list after connection and sensors enabled.
             self._tags[addy] = tag
-            return
         except:
             self.logger.exception(
                 "Failed to connect to {} ({}). Retrying...".format(name, addy))
             self._notify_status_signal('Retrying', addy)
             # Make sure to remove tag if connect fails
             self._tags.pop(addy, None)
-            self._connect_tag(cfg)
         else:
             self.logger.info("Connected to device {}".format(addy))
             self._notify_status_signal('Connected', addy)

--- a/sensor_tag_read_block.py
+++ b/sensor_tag_read_block.py
@@ -1,5 +1,4 @@
 from threading import Lock
-from time import sleep
 from bluepy.sensortag import SensorTag
 from bluepy.sensortag import KeypressDelegate as _KeypressDelegate
 from bluepy.btle import BTLEException
@@ -157,7 +156,6 @@ class SensorTagRead(Block):
             self._notify_status_signal('Retrying', addy)
             # Make sure to remove tag if connect fails
             self._tags.pop(addy, None)
-            sleep(5)
             self._connect_tag(cfg)
         else:
             self.logger.info("Connected to device {}".format(addy))

--- a/sensor_tag_read_block.py
+++ b/sensor_tag_read_block.py
@@ -141,34 +141,34 @@ class SensorTagRead(Block):
     def _connect_tag(self, cfg, read_on_connect=False):
         addy = cfg["address"]
         name = cfg["name"]
-        try:
-            self.logger.info("Push {} side button NOW".format(name))
-            self.logger.info("Connecting to device {}".format(addy))
-            self._notify_status_signal('Connecting', addy)
-            tag = SensorTag(addy)
-            self._enable_sensors(addy, tag)
-            # Save the tag to the list after connection and sensors enabled.
-            self._tags[addy] = tag
-        except:
-            self.logger.exception(
-                "Failed to connect to {} ({}). Retrying...".format(name, addy))
-            self._notify_status_signal('Retrying', addy)
-            # Make sure to remove tag if connect fails
-            self._tags.pop(addy, None)
-        else:
-            self.logger.info("Connected to device {}".format(addy))
-            self._notify_status_signal('Connected', addy)
-            self._read_counter = 0
-            if cfg["sensors"].get('keypress', False):
-                self.logger.info(
-                    "Enabling notification listening for keypress")
-                spawn(self._listen_for_notifications, addy)
-            if read_on_connect:
-                self.logger.debug(
-                    "Reading from sensors on reconnect")
-                self._read_from_tag(addy)
-            return
-        spawn(self._connect_tag(cfg))
+        while addy not in self._tags:
+            try:
+                self.logger.info("Push {} side button NOW".format(name))
+                self.logger.info("Connecting to device {}".format(addy))
+                self._notify_status_signal('Connecting', addy)
+                tag = SensorTag(addy)
+                self._enable_sensors(addy, tag)
+                # Save tag to the list after connection and sensors enabled
+                self._tags[addy] = tag
+            except:
+                self.logger.exception(
+                    "Failed to connect to {} ({}). Retrying...".format(
+                        name, addy))
+                self._notify_status_signal('Retrying', addy)
+                # Make sure to remove tag if connect fails
+                self._tags.pop(addy, None)
+            else:
+                self.logger.info("Connected to device {}".format(addy))
+                self._notify_status_signal('Connected', addy)
+                self._read_counter = 0
+                if cfg["sensors"].get('keypress', False):
+                    self.logger.info(
+                        "Enabling notification listening for keypress")
+                    spawn(self._listen_for_notifications, addy)
+                if read_on_connect:
+                    self.logger.debug(
+                        "Reading from sensors on reconnect")
+                    self._read_from_tag(addy)
 
     def _enable_sensors(self, addy, tag):
         self.logger.info("Enabling sensors: {}".format(addy))

--- a/sensor_tag_read_block.py
+++ b/sensor_tag_read_block.py
@@ -150,7 +150,8 @@ class SensorTagRead(Block):
             self._enable_sensors(addy, tag)
             # Save the tag to the list after connection and sensors enabled.
             self._tags[addy] = tag
-        except Exception as e:
+            return
+        except:
             self.logger.exception(
                 "Failed to connect to {} ({}). Retrying...".format(name, addy))
             self._notify_status_signal('Retrying', addy)
@@ -170,6 +171,8 @@ class SensorTagRead(Block):
                 self.logger.debug(
                     "Reading from sensors on reconnect")
                 self._read_from_tag(addy)
+            return
+        spawn(self._connect_tag(cfg))
 
     def _enable_sensors(self, addy, tag):
         self.logger.info("Enabling sensors: {}".format(addy))
@@ -207,7 +210,7 @@ class SensorTagRead(Block):
         """ Reads from sensors notify a Signal. """
         # Don't let too many reads queue up when sensor reads are slow
         if self._read_counter > 5:
-            self.logger.debug(
+            self.logger.warning(
                 "Skipping read. Too many in progress: {}".format(addy))
             return
         try:


### PR DESCRIPTION
previously `_connect_tag` was being called inside the context of an Exception, so every exception raised referenced the exception before it. Eventually this monster process is killed, raising `RuntimeError: maximum recursion depth exceeded`

This fix simply calls the next connection attempt 1) outside the context of the current Exception, and 2) in another thread.